### PR TITLE
fixed vertical flip function bug in Ch4

### DIFF
--- a/Chapter04/Ch4_Scirpts.ipynb
+++ b/Chapter04/Ch4_Scirpts.ipynb
@@ -587,13 +587,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
     "def random_vflip(image,label):\n",
     "    w,h=image.size\n",
     "    x,y=label\n",
     "\n",
     "    image = TF.vflip(image)\n",
-    "    label = x, w-y\n",
+    "    label = x, h-y\n",
     "    return image, label"
    ]
   },
@@ -1938,7 +1937,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
For the vertical flip, the centroid y coordinate of the label should be subtracted from image height, rather from image width. Therefore I replaced,
`label = x, w-y
`
with
`label = x, h-y
`